### PR TITLE
Nested dictionary and plural forms into string

### DIFF
--- a/__test__/nested-dictionary.test.js
+++ b/__test__/nested-dictionary.test.js
@@ -1,0 +1,36 @@
+import translate from '../src/translator'
+
+describe('translater nested dictionary', () => {
+  const dictionary = {
+    key_1: "First text",
+    key_2: [ "$count", " ", [ "hour", "hours"] ],
+    'level1.level2.value1': 'first level value',
+    level1: {
+      level1value: 'bla bla',
+      level2: {
+        value1: 'nested value 1',
+        value2: 'nested value 2',
+        value3: [ "$count", " ", [ "hour", "hours"] ]
+      }
+    }
+  }
+
+  it('should return first level value if exist', () => {
+    expect( translate(dictionary, 'en', 'level1.level2.value1')).toEqual( "first level value" )
+  })
+
+  it('should return nested level value if non exist first level', () => {
+    expect( translate(dictionary, 'en', 'level1.level2.value2')).toEqual( "nested value 2" )
+  })
+
+  it('should normal work with nested dict and plural', () => {
+    expect( translate(dictionary, 'en', 'level1.level2.value3', 1)).toEqual( "1 hour" )
+  })
+
+  it('should throw error if key missing', () => {
+    spyOn(console, 'error')
+    expect( translate(dictionary, 'en', 'level1.level2.value')).toEqual( "<No level1.level2.value key for en>" )
+    expect(console.error).toHaveBeenCalled()
+  })
+
+})

--- a/__test__/plural-string.test.js
+++ b/__test__/plural-string.test.js
@@ -1,0 +1,19 @@
+import translate from '../src/translator'
+
+describe('translater nested dictionary', () => {
+  const dictionary = {
+    level1: {
+      plural1: 'bla bla [ "$count", " ", [ "hour", "hours"] ] foo foo',
+      level2: {
+        value1: 'nested value 1',
+        value2: 'nested value 2',
+        value3: [ "$count", " ", [ "hour", "hours"] ]
+      }
+    }
+  }
+
+  it('should return plural form in string', () => {
+    expect( translate(dictionary, 'en', 'level1.plural1', 1)).toEqual( "bla bla 1 hour foo foo" )
+  })
+
+})

--- a/__test__/plural-string.test.js
+++ b/__test__/plural-string.test.js
@@ -3,7 +3,7 @@ import translate from '../src/translator'
 describe('translater nested dictionary', () => {
   const dictionary = {
     level1: {
-      plural1: 'bla bla [ "$count", " ", [ "hour", "hours"] ] foo foo',
+      plural1: 'My cat kill [ "$count", " ", [ "mouse", "mice"] ] and [$count," ",["bird","birds"]] today',
       level2: {
         value1: 'nested value 1',
         value2: 'nested value 2',
@@ -13,7 +13,7 @@ describe('translater nested dictionary', () => {
   }
 
   it('should return plural form in string', () => {
-    expect( translate(dictionary, 'en', 'level1.plural1', 1)).toEqual( "bla bla 1 hour foo foo" )
+    expect( translate(dictionary, 'en', 'level1.plural1', 1, 2)).toEqual( "My cat kill 1 mouse and 2 birds today" )
   })
 
 })

--- a/src/translator.js
+++ b/src/translator.js
@@ -7,6 +7,25 @@
 
 import pluralize from 'pluralizr';
 
+const getValue = function( currentLangDictionary, key ) {
+
+      if ( key in currentLangDictionary ) {
+            return currentLangDictionary[key];
+      }
+
+      let keys = key.split('.');
+      let value = currentLangDictionary;
+
+      while (keys.length > 0) {
+            key = keys.shift();
+            value = value[key];
+
+            if (value == undefined) break;
+      }
+
+      return value;
+};
+
 const pluralLocalize = function( languageCode, pluralStrings, number ) {
 
     switch ( typeof pluralStrings ) {
@@ -52,14 +71,18 @@ const translate = function( currentLangDictionary, languageCode, key, number ) {
     if ( !currentLangDictionary ) {
         console.error( "i18n: localize: no dictionary" );
         return "<i18n Error>";
-    } else if ( currentLangDictionary[key] || currentLangDictionary[key] === '' ) {
+    }
+
+    let value = getValue( currentLangDictionary, key );
+
+    if ( value ) {
 
         if ( !number && number !== 0 ) {
             // Just take a string from dictionary
-            return currentLangDictionary[key];
+            return value;
         } else {
             // Use pluralize mechanics
-            return pluralLocalize(languageCode, currentLangDictionary[key], number);
+            return pluralLocalize(languageCode, value, number);
         }
 
     } else {

--- a/src/translator.js
+++ b/src/translator.js
@@ -35,15 +35,15 @@ const pluralLocalize = function( languageCode, pluralStrings, numbers ) {
         case 'string':
             let match = pluralStrings.match(/\[(.*?\])\s*\]/g)
             if ( match ) {
-              match.forEach((pluralArray) => {
-              	let a = pluralArray.match(/\[.*(\[(.*?)\])\s*\]/)
-                let b = pluralArray.replace(a[1], '')
-                let c = b.split(',')
-                console.log([c[0], c[1], a[2].split(',')])
-                pluralStrings = pluralStrings.replace(pluralArray, pluralLocalize( languageCode, [c[0], c[1], a[2].split(',')], [numbers.shift()]))
-              })
+              match.forEach((matchData) => {
+                let pluralMatch = matchData.match(/\[.*(\[(.*?)\])\s*\]/);
+                let pluralObject = pluralMatch[2].split(",").map((text) => { return text.replace(/\'|\"|\s+/g, '') });
+                let pluralArray = pluralMatch[0].split(",");
+                let count = pluralArray[0].replace(/\[|\s+|\"|\'/g, '');
+                let seporator = pluralArray[1].match(/\'([^\']*)\'|\"([^\"]*)/)[2];
+                pluralStrings = pluralStrings.replace(matchData, pluralLocalize( languageCode, [count, seporator, pluralObject], [numbers.shift()]));
+              });
             }
-            //let wordPattern = /\'([^\']*)\'|\"([^\"]*)|(\w+)\"/g
 
             // If no need in forms, but we want to replace "$Count" with number
             return pluralStrings.replace( "$Count", number );

--- a/src/translator.js
+++ b/src/translator.js
@@ -26,11 +26,25 @@ const getValue = function( currentLangDictionary, key ) {
       return value;
 };
 
-const pluralLocalize = function( languageCode, pluralStrings, number ) {
+const pluralLocalize = function( languageCode, pluralStrings, numbers ) {
+
+    let number = numbers[0];
 
     switch ( typeof pluralStrings ) {
 
         case 'string':
+            let match = pluralStrings.match(/\[(.*?\])\s*\]/g)
+            if ( match ) {
+              match.forEach((pluralArray) => {
+              	let a = pluralArray.match(/\[.*(\[(.*?)\])\s*\]/)
+                let b = pluralArray.replace(a[1], '')
+                let c = b.split(',')
+                console.log([c[0], c[1], a[2].split(',')])
+                pluralStrings = pluralStrings.replace(pluralArray, pluralLocalize( languageCode, [c[0], c[1], a[2].split(',')], [numbers.shift()]))
+              })
+            }
+            //let wordPattern = /\'([^\']*)\'|\"([^\"]*)|(\w+)\"/g
+
             // If no need in forms, but we want to replace "$Count" with number
             return pluralStrings.replace( "$Count", number );
 
@@ -62,7 +76,7 @@ const pluralLocalize = function( languageCode, pluralStrings, number ) {
     }
 };
 
-const translate = function( currentLangDictionary, languageCode, key, number ) {
+const translate = function( currentLangDictionary, languageCode, key, ...numbers ) {
 
     if ( languageCode === "keys" ) {
         return key; // If we want to see keys without translate
@@ -77,12 +91,12 @@ const translate = function( currentLangDictionary, languageCode, key, number ) {
 
     if ( value ) {
 
-        if ( !number && number !== 0 ) {
+        if ( numbers && numbers.length > 0 ) {
+            // Use pluralize mechanics
+            return pluralLocalize(languageCode, value, numbers);
+        } else {
             // Just take a string from dictionary
             return value;
-        } else {
-            // Use pluralize mechanics
-            return pluralLocalize(languageCode, value, number);
         }
 
     } else {


### PR DESCRIPTION
Добавил поддержку вложенных словарей вида:
{
  level1:{
    key1: 'value1',
    key2: 'value2'
  }
}
и доступом к значению по ключу level1.key1. Если такой ключ есть на первом уровне то он будет в приоритете.

И вторая фича наиболее не очевидная, и в коде тоже. Возможность плюралки вкладывать в строку и добавлять более одного аргумента.  
__test__/plural-string.test.js говорит как бы сам за себя.